### PR TITLE
MIND-8: Create countdown timer logic

### DIFF
--- a/ios/Flutter/Debug.xcconfig
+++ b/ios/Flutter/Debug.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Generated.xcconfig"

--- a/ios/Flutter/Release.xcconfig
+++ b/ios/Flutter/Release.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Generated.xcconfig"

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,0 +1,43 @@
+# Uncomment this line to define a global platform for your project
+# platform :ios, '13.0'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure flutter pub get is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Generated.xcconfig, then run flutter pub get"
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_ios_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+
+  flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
+  target 'RunnerTests' do
+    inherit! :search_paths
+  end
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_ios_build_settings(target)
+  end
+end

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -21,8 +21,13 @@
  */
 
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'app.dart';
 
 void main() {
-  runApp(const EleuMindApp());
+  runApp(
+    const ProviderScope(
+      child: EleuMindApp(),
+    ),
+  );
 }

--- a/lib/screens/timer_screen.dart
+++ b/lib/screens/timer_screen.dart
@@ -31,7 +31,8 @@ class TimerScreen extends ConsumerStatefulWidget {
   ConsumerState<TimerScreen> createState() => _TimerScreenState();
 }
 
-class _TimerScreenState extends ConsumerState<TimerScreen> with WidgetsBindingObserver {
+class _TimerScreenState extends ConsumerState<TimerScreen>
+    with WidgetsBindingObserver {
   @override
   void initState() {
     super.initState();

--- a/lib/screens/timer_screen.dart
+++ b/lib/screens/timer_screen.dart
@@ -20,7 +20,6 @@
  * along with EleuMind.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import 'dart:ui';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../services/timer_service.dart';

--- a/lib/screens/timer_screen.dart
+++ b/lib/screens/timer_screen.dart
@@ -52,7 +52,7 @@ class _TimerScreenState extends ConsumerState<TimerScreen> with WidgetsBindingOb
       case AppLifecycleState.paused:
       case AppLifecycleState.inactive:
       case AppLifecycleState.detached:
-      case AppLifecycleState.hidden: // <-- add this
+      case AppLifecycleState.hidden:
         notifier.onAppPaused();
         break;
       case AppLifecycleState.resumed:
@@ -96,6 +96,7 @@ class _TimerScreenState extends ConsumerState<TimerScreen> with WidgetsBindingOb
                   ExcludeSemantics(
                     child: Text(
                       formatDuration(timerState.remainingDuration),
+                      key: const Key('timerText'),
                       style: textTheme.displayLarge?.copyWith(
                         fontFeatures: const [FontFeature.tabularFigures()],
                       ),

--- a/lib/screens/timer_screen.dart
+++ b/lib/screens/timer_screen.dart
@@ -20,15 +20,49 @@
  * along with EleuMind.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+import 'dart:ui';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../services/timer_service.dart';
 
-class TimerScreen extends ConsumerWidget {
+class TimerScreen extends ConsumerStatefulWidget {
   const TimerScreen({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<TimerScreen> createState() => _TimerScreenState();
+}
+
+class _TimerScreenState extends ConsumerState<TimerScreen> with WidgetsBindingObserver {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    final notifier = ref.read(timerProvider.notifier);
+    switch (state) {
+      case AppLifecycleState.paused:
+      case AppLifecycleState.inactive:
+      case AppLifecycleState.detached:
+      case AppLifecycleState.hidden: // <-- add this
+        notifier.onAppPaused();
+        break;
+      case AppLifecycleState.resumed:
+        notifier.onAppResumed();
+        break;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
     final timerState = ref.watch(timerProvider);
     final timerNotifier = ref.read(timerProvider.notifier);
     final textTheme = Theme.of(context).textTheme;
@@ -57,7 +91,7 @@ class TimerScreen extends ConsumerWidget {
                     ),
                     const SizedBox(height: 32),
                   ],
-                  
+
                   // Countdown display.
                   ExcludeSemantics(
                     child: Text(
@@ -68,14 +102,14 @@ class TimerScreen extends ConsumerWidget {
                     ),
                   ),
                   const SizedBox(height: 12),
-                  
+
                   // Status label.
                   Text(
                     _getStatusLabel(timerState.status),
                     style: textTheme.titleMedium,
                   ),
                   const SizedBox(height: 32),
-                  
+
                   // Control buttons.
                   _ControlButtons(
                     status: timerState.status,

--- a/lib/services/timer_service.dart
+++ b/lib/services/timer_service.dart
@@ -96,7 +96,6 @@ class TimerNotifier extends StateNotifier<TimerState> {
         pausedDuration: Duration.zero,
       );
       _startTicker();
-      _updateRemainingTime();
     } else if (state.status == TimerStatus.paused) {
       resume();
     }
@@ -124,7 +123,6 @@ class TimerNotifier extends StateNotifier<TimerState> {
         startedAt: _now(),
       );
       _startTicker();
-      _updateRemainingTime();
     }
   }
 

--- a/lib/services/timer_service.dart
+++ b/lib/services/timer_service.dart
@@ -1,0 +1,182 @@
+/*
+ * EleuMind
+ * A privacy-first, offline meditation timer.
+ * 
+ * Copyright (C) 2025 EleuCode
+ *
+ * This file is part of EleuMind.
+ *
+ * EleuMind is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EleuMind is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EleuMind.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import 'dart:async';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+enum TimerStatus { idle, running, paused }
+
+class TimerState {
+  final Duration totalDuration;
+  final Duration remainingDuration;
+  final TimerStatus status;
+  final DateTime? startedAt;
+  final Duration? pausedDuration;
+
+  const TimerState({
+    required this.totalDuration,
+    required this.remainingDuration,
+    required this.status,
+    this.startedAt,
+    this.pausedDuration,
+  });
+
+  TimerState copyWith({
+    Duration? totalDuration,
+    Duration? remainingDuration,
+    TimerStatus? status,
+    DateTime? startedAt,
+    Duration? pausedDuration,
+  }) {
+    return TimerState(
+      totalDuration: totalDuration ?? this.totalDuration,
+      remainingDuration: remainingDuration ?? this.remainingDuration,
+      status: status ?? this.status,
+      startedAt: startedAt ?? this.startedAt,
+      pausedDuration: pausedDuration ?? this.pausedDuration,
+    );
+  }
+
+  static TimerState initial({Duration duration = const Duration(minutes: 5)}) {
+    return TimerState(
+      totalDuration: duration,
+      remainingDuration: duration,
+      status: TimerStatus.idle,
+    );
+  }
+}
+
+class TimerNotifier extends StateNotifier<TimerState> {
+  Timer? _ticker;
+
+  TimerNotifier() : super(TimerState.initial());
+
+  void setDuration(Duration duration) {
+    if (state.status == TimerStatus.idle) {
+      state = TimerState(
+        totalDuration: duration,
+        remainingDuration: duration,
+        status: TimerStatus.idle,
+      );
+    }
+  }
+
+  void start() {
+    if (state.status == TimerStatus.idle) {
+      state = state.copyWith(
+        status: TimerStatus.running,
+        startedAt: DateTime.now(),
+        pausedDuration: Duration.zero,
+      );
+      _startTicker();
+    } else if (state.status == TimerStatus.paused) {
+      resume();
+    }
+  }
+
+  void pause() {
+    if (state.status == TimerStatus.running) {
+      _ticker?.cancel();
+      
+      // Calculate elapsed time since start or last resume.
+      final elapsed = DateTime.now().difference(state.startedAt!);
+      final totalElapsed = elapsed + (state.pausedDuration ?? Duration.zero);
+      final remaining = state.totalDuration - totalElapsed;
+
+      state = state.copyWith(
+        status: TimerStatus.paused,
+        remainingDuration: remaining.isNegative ? Duration.zero : remaining,
+        pausedDuration: totalElapsed,
+      );
+    }
+  }
+
+  void resume() {
+    if (state.status == TimerStatus.paused) {
+      state = state.copyWith(
+        status: TimerStatus.running,
+        startedAt: DateTime.now(),
+        // Keep the pausedDuration to calculate total elapsed correctly.
+      );
+      _startTicker();
+    }
+  }
+
+  void stop() {
+    _ticker?.cancel();
+    state = TimerState.initial(duration: state.totalDuration);
+  }
+
+  void _startTicker() {
+    _ticker?.cancel();
+    _ticker = Timer.periodic(const Duration(milliseconds: 100), (_) {
+      _updateRemainingTime();
+    });
+  }
+
+  void _updateRemainingTime() {
+    if (state.status != TimerStatus.running) return;
+
+    // Wall-clock safe calculation.
+    final elapsed = DateTime.now().difference(state.startedAt!);
+    final totalElapsed = elapsed + (state.pausedDuration ?? Duration.zero);
+    final remaining = state.totalDuration - totalElapsed;
+
+    if (remaining <= Duration.zero) {
+      _ticker?.cancel();
+      state = state.copyWith(
+        remainingDuration: Duration.zero,
+        status: TimerStatus.idle,
+      );
+      // Timer completed - could trigger a callback here.
+    } else {
+      state = state.copyWith(remainingDuration: remaining);
+    }
+  }
+
+  @override
+  void dispose() {
+    _ticker?.cancel();
+    super.dispose();
+  }
+}
+
+// Provider definition.
+final timerProvider = StateNotifierProvider<TimerNotifier, TimerState>((ref) {
+  return TimerNotifier();
+});
+
+// Convenience providers.
+final timerStatusProvider = Provider<TimerStatus>((ref) {
+  return ref.watch(timerProvider).status;
+});
+
+final remainingDurationProvider = Provider<Duration>((ref) {
+  return ref.watch(timerProvider).remainingDuration;
+});
+
+// Format duration for display (total minutes:seconds).
+String formatDuration(Duration duration) {
+  final minutes = duration.inMinutes;
+  final seconds = duration.inSeconds.remainder(60);
+  return '${minutes.toString().padLeft(2, '0')}:${seconds.toString().padLeft(2, '0')}';
+}

--- a/lib/services/timer_service.dart
+++ b/lib/services/timer_service.dart
@@ -74,7 +74,9 @@ class TimerNotifier extends StateNotifier<TimerState> {
   Timer? _ticker;
   final Now _now;
 
-  TimerNotifier({Now now = DateTime.now}) : _now = now, super(TimerState.initial());
+  TimerNotifier({Now now = DateTime.now})
+      : _now = now,
+        super(TimerState.initial());
 
   static const _prefsKey = 'eleumind.timer.v1';
 
@@ -222,8 +224,12 @@ class TimerNotifier extends StateNotifier<TimerState> {
         totalDuration: Duration(milliseconds: j['total'] as int),
         remainingDuration: Duration(milliseconds: j['remaining'] as int),
         status: TimerStatus.values[j['status'] as int],
-        startedAt: (j['startedAt'] as String?) != null ? DateTime.parse(j['startedAt'] as String) : null,
-        pausedDuration: (j['paused'] as int?) != null ? Duration(milliseconds: j['paused'] as int) : null,
+        startedAt: (j['startedAt'] as String?) != null
+            ? DateTime.parse(j['startedAt'] as String)
+            : null,
+        pausedDuration: (j['paused'] as int?) != null
+            ? Duration(milliseconds: j['paused'] as int)
+            : null,
       );
     } catch (_) {
       return null;

--- a/macos/Flutter/Flutter-Debug.xcconfig
+++ b/macos/Flutter/Flutter-Debug.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "ephemeral/Flutter-Generated.xcconfig"

--- a/macos/Flutter/Flutter-Release.xcconfig
+++ b/macos/Flutter/Flutter-Release.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "ephemeral/Flutter-Generated.xcconfig"

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,6 +5,8 @@
 import FlutterMacOS
 import Foundation
 
+import shared_preferences_foundation
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
 }

--- a/macos/Podfile
+++ b/macos/Podfile
@@ -1,0 +1,42 @@
+platform :osx, '10.15'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'ephemeral', 'Flutter-Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure \"flutter pub get\" is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Flutter-Generated.xcconfig, then run \"flutter pub get\""
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_macos_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+
+  flutter_install_all_macos_pods File.dirname(File.realpath(__FILE__))
+  target 'RunnerTests' do
+    inherit! :search_paths
+  end
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_macos_build_settings(target)
+  end
+end

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -70,6 +70,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.0.0"
+  flutter_riverpod:
+    dependency: "direct main"
+    description:
+      name: flutter_riverpod
+      sha256: "9532ee6db4a943a1ed8383072a2e3eeda041db5657cdf6d2acecf3c21ecbe7e1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.6.1"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -139,6 +147,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  riverpod:
+    dependency: transitive
+    description:
+      name: riverpod
+      sha256: "59062512288d3056b2321804332a13ffdd1bf16df70dcc8e506e411280a72959"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.6.1"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -160,6 +176,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.12.1"
+  state_notifier:
+    dependency: transitive
+    description:
+      name: state_notifier
+      sha256: b8677376aa54f2d7c58280d5a007f9e8774f1968d1fb1c096adcb4792fba29bb
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   stream_channel:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -57,6 +57,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.3"
+  ffi:
+    dependency: transitive
+    description:
+      name: ffi
+      sha256: "289279317b4b16eb2bb7e271abccd4bf84ec9bdcbe999e278a94b804f5630418"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.4"
+  file:
+    dependency: transitive
+    description:
+      name: file
+      sha256: a3b4f84adafef897088c160faf7dfffb7696046cb13ae90b508c2cbc95d3b8d4
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -80,6 +96,11 @@ packages:
     version: "2.6.1"
   flutter_test:
     dependency: "direct dev"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
+  flutter_web_plugins:
+    dependency: transitive
     description: flutter
     source: sdk
     version: "0.0.0"
@@ -147,6 +168,46 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  path_provider_linux:
+    dependency: transitive
+    description:
+      name: path_provider_linux
+      sha256: f7a1fe3a634fe7734c8d3f2766ad746ae2a2884abe22e241a8b301bf5cac3279
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.1"
+  path_provider_platform_interface:
+    dependency: transitive
+    description:
+      name: path_provider_platform_interface
+      sha256: "88f5779f72ba699763fa3a3b06aa4bf6de76c8e5de842cf6f29e2e06476c2334"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.2"
+  path_provider_windows:
+    dependency: transitive
+    description:
+      name: path_provider_windows
+      sha256: bd6f00dbd873bfb70d0761682da2b3a2c2fccc2b9e84c495821639601d81afe7
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.0"
+  platform:
+    dependency: transitive
+    description:
+      name: platform
+      sha256: "5d6b1b0036a5f331ebc77c850ebc8506cbc1e9416c27e59b439f917a902a4984"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.6"
+  plugin_platform_interface:
+    dependency: transitive
+    description:
+      name: plugin_platform_interface
+      sha256: "4820fbfdb9478b1ebae27888254d445073732dae3d6ea81f0b7e06d5dedc3f02"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.8"
   riverpod:
     dependency: transitive
     description:
@@ -155,6 +216,62 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.6.1"
+  shared_preferences:
+    dependency: "direct main"
+    description:
+      name: shared_preferences
+      sha256: "6e8bf70b7fef813df4e9a36f658ac46d107db4b4cfe1048b477d4e453a8159f5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.3"
+  shared_preferences_android:
+    dependency: transitive
+    description:
+      name: shared_preferences_android
+      sha256: a2608114b1ffdcbc9c120eb71a0e207c71da56202852d4aab8a5e30a82269e74
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.12"
+  shared_preferences_foundation:
+    dependency: transitive
+    description:
+      name: shared_preferences_foundation
+      sha256: "6a52cfcdaeac77cad8c97b539ff688ccfc458c007b4db12be584fbe5c0e49e03"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.4"
+  shared_preferences_linux:
+    dependency: transitive
+    description:
+      name: shared_preferences_linux
+      sha256: "580abfd40f415611503cae30adf626e6656dfb2f0cee8f465ece7b6defb40f2f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_platform_interface:
+    dependency: transitive
+    description:
+      name: shared_preferences_platform_interface
+      sha256: "57cbf196c486bc2cf1f02b85784932c6094376284b3ad5779d1b1c6c6a816b80"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_web:
+    dependency: transitive
+    description:
+      name: shared_preferences_web
+      sha256: c49bd060261c9a3f0ff445892695d6212ff603ef3115edbb448509d407600019
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.3"
+  shared_preferences_windows:
+    dependency: transitive
+    description:
+      name: shared_preferences_windows
+      sha256: "94ef0f72b2d71bc3e700e025db3710911bd51a71cefb65cc609dd0d9a982e3c1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -232,6 +349,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "15.0.2"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: "868d88a33d8a87b18ffc05f9f030ba328ffefba92d6c127917a2ba740f9cfe4a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.1"
+  xdg_directories:
+    dependency: transitive
+    description:
+      name: xdg_directories
+      sha256: "7a3f37b05d989967cdddcbb571f1ea834867ae2faa29725fd085180e0883aa15"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
 sdks:
   dart: ">=3.8.0-0 <4.0.0"
-  flutter: ">=3.18.0-18.0.pre.54"
+  flutter: ">=3.29.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,89 +1,21 @@
 name: eleumind
 description: "A new Flutter project."
-# The following line prevents the package from being accidentally published to
-# pub.dev using `flutter pub publish`. This is preferred for private packages.
-publish_to: 'none' # Remove this line if you wish to publish to pub.dev
-
-# The following defines the version and build number for your application.
-# A version number is three numbers separated by dots, like 1.2.43
-# followed by an optional build number separated by a +.
-# Both the version and the builder number may be overridden in flutter
-# build by specifying --build-name and --build-number, respectively.
-# In Android, build-name is used as versionName while build-number used as versionCode.
-# Read more about Android versioning at https://developer.android.com/studio/publish/versioning
-# In iOS, build-name is used as CFBundleShortVersionString while build-number is used as CFBundleVersion.
-# Read more about iOS versioning at
-# https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-# In Windows, build-name is used as the major, minor, and patch parts
-# of the product and file versions while build-number is used as the build suffix.
-version: 1.0.0+1
+publish_to: 'none'
+version: 0.1.0+1
 
 environment:
   sdk: ">=3.5.0 <4.0.0"
 
-# Dependencies specify other packages that your package needs in order to work.
-# To automatically upgrade your package dependencies to the latest versions
-# consider running `flutter pub upgrade --major-versions`. Alternatively,
-# dependencies can be manually updated by changing the version numbers below to
-# the latest version available on pub.dev. To see which dependencies have newer
-# versions available, run `flutter pub outdated`.
 dependencies:
   flutter:
     sdk: flutter
-
-  # The following adds the Cupertino Icons font to your application.
-  # Use with the CupertinoIcons class for iOS style icons.
+  flutter_riverpod: ^2.6.1
   cupertino_icons: ^1.0.8
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-
-  # The "flutter_lints" package below contains a set of recommended lints to
-  # encourage good coding practices. The lint set provided by the package is
-  # activated in the `analysis_options.yaml` file located at the root of your
-  # package. See that file for information about deactivating specific lint
-  # rules and activating additional ones.
   flutter_lints: ^5.0.0
 
-# For information on the generic Dart part of this file, see the
-# following page: https://dart.dev/tools/pub/pubspec
-
-# The following section is specific to Flutter packages.
 flutter:
-
-  # The following line ensures that the Material Icons font is
-  # included with your application, so that you can use the icons in
-  # the material Icons class.
   uses-material-design: true
-
-  # To add assets to your application, add an assets section, like this:
-  # assets:
-  #   - images/a_dot_burr.jpeg
-  #   - images/a_dot_ham.jpeg
-
-  # An image asset can refer to one or more resolution-specific "variants", see
-  # https://flutter.dev/to/resolution-aware-images
-
-  # For details regarding adding assets from package dependencies, see
-  # https://flutter.dev/to/asset-from-package
-
-  # To add custom fonts to your application, add a fonts section here,
-  # in this "flutter" section. Each entry in this list should have a
-  # "family" key with the font family name, and a "fonts" key with a
-  # list giving the asset and other descriptors for the font. For
-  # example:
-  # fonts:
-  #   - family: Schyler
-  #     fonts:
-  #       - asset: fonts/Schyler-Regular.ttf
-  #       - asset: fonts/Schyler-Italic.ttf
-  #         style: italic
-  #   - family: Trajan Pro
-  #     fonts:
-  #       - asset: fonts/TrajanPro.ttf
-  #       - asset: fonts/TrajanPro_Bold.ttf
-  #         weight: 700
-  #
-  # For details regarding fonts from package dependencies,
-  # see https://flutter.dev/to/font-from-package

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: eleumind
-description: "A new Flutter project."
+description: "A privacy-first, offline meditation timer."
 publish_to: 'none'
 version: 0.1.0+1
 
@@ -10,6 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_riverpod: ^2.6.1
+  shared_preferences: ^2.3.2
   cupertino_icons: ^1.0.8
 
 dev_dependencies:

--- a/test/app_test.dart
+++ b/test/app_test.dart
@@ -1,22 +1,60 @@
+/*
+ * EleuMind
+ * A privacy-first, offline meditation timer.
+ * 
+ * Copyright (C) 2025 EleuCode
+ *
+ * This file is part of EleuMind.
+ *
+ * EleuMind is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EleuMind is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EleuMind.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:eleumind/app.dart';
 import 'package:eleumind/screens/timer_screen.dart';
 
 void main() {
   testWidgets('App provides a MaterialApp shell', (tester) async {
-    await tester.pumpWidget(const EleuMindApp());
+    await tester.pumpWidget(
+      const ProviderScope(
+        child: EleuMindApp(),
+      ),
+    );
+    
     expect(find.byType(MaterialApp), findsOneWidget);
   });
 
   testWidgets('App uses dark theme mode by default', (tester) async {
-    await tester.pumpWidget(const EleuMindApp());
+    await tester.pumpWidget(
+      const ProviderScope(
+        child: EleuMindApp(),
+      ),
+    );
+    
     final app = tester.widget<MaterialApp>(find.byType(MaterialApp));
     expect(app.themeMode, ThemeMode.dark);
   });
 
   testWidgets('App home is TimerScreen', (tester) async {
-    await tester.pumpWidget(const EleuMindApp());
+    await tester.pumpWidget(
+      const ProviderScope(
+        child: EleuMindApp(),
+      ),
+    );
+    
     expect(find.byType(TimerScreen), findsOneWidget);
   });
 }

--- a/test/app_test.dart
+++ b/test/app_test.dart
@@ -33,7 +33,7 @@ void main() {
         child: EleuMindApp(),
       ),
     );
-    
+
     expect(find.byType(MaterialApp), findsOneWidget);
   });
 
@@ -43,7 +43,7 @@ void main() {
         child: EleuMindApp(),
       ),
     );
-    
+
     final app = tester.widget<MaterialApp>(find.byType(MaterialApp));
     expect(app.themeMode, ThemeMode.dark);
   });
@@ -54,7 +54,7 @@ void main() {
         child: EleuMindApp(),
       ),
     );
-    
+
     expect(find.byType(TimerScreen), findsOneWidget);
   });
 }

--- a/test/screens/timer_screen_test.dart
+++ b/test/screens/timer_screen_test.dart
@@ -24,8 +24,13 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:eleumind/app.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {
+  setUpAll(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
   group('TimerScreen', () {
     testWidgets('shows initial duration and Ready status', (tester) async {
       await tester.pumpWidget(
@@ -101,7 +106,7 @@ void main() {
 
       await tester.tap(find.text('Start'));
       await tester.pump();
-      
+
       await tester.tap(find.text('Pause'));
       await tester.pump();
 
@@ -119,10 +124,10 @@ void main() {
 
       await tester.tap(find.text('Start'));
       await tester.pump();
-      
+
       await tester.tap(find.text('Pause'));
       await tester.pump();
-      
+
       await tester.tap(find.text('Resume'));
       await tester.pump();
 
@@ -138,7 +143,7 @@ void main() {
 
       await tester.tap(find.text('Start'));
       await tester.pump();
-      
+
       await tester.tap(find.text('Stop'));
       await tester.pump();
 
@@ -146,33 +151,30 @@ void main() {
       expect(find.text('05:00'), findsOneWidget);
     });
 
-    testWidgets('countdown decrements while running', (tester) async {
+    testWidgets('countdown decrements while running (1s tick)', (tester) async {
       await tester.pumpWidget(
         const ProviderScope(
           child: EleuMindApp(),
         ),
       );
 
-      // Set a short duration for testing.
       await tester.tap(find.text('1 min'));
       await tester.pump();
 
       await tester.tap(find.text('Start'));
       await tester.pump();
-      
+
       expect(find.text('01:00'), findsOneWidget);
-      
-      // Wait a bit and pump periodically.
+
       await tester.pump(const Duration(milliseconds: 1100));
-      
-      // Time should have decreased.
+
+      // Time should have decreased
       final textFinder = find.byType(Text);
       final texts = tester.widgetList<Text>(textFinder);
-      final timerText = texts.firstWhere(
+      final maybeTimerText = texts.firstWhere(
         (text) => text.data != null && text.data!.contains(':'),
       );
-      
-      expect(timerText.data, isNot('01:00'));
+      expect(maybeTimerText.data, isNot('01:00'));
     });
   });
 }

--- a/test/screens/timer_screen_test.dart
+++ b/test/screens/timer_screen_test.dart
@@ -151,7 +151,7 @@ void main() {
       expect(find.text('05:00'), findsOneWidget);
     });
 
-    testWidgets('countdown decrements while running (1s tick)', (tester) async {
+    testWidgets('countdown decrements while running (robust to alignment)', (tester) async {
       await tester.pumpWidget(
         const ProviderScope(
           child: EleuMindApp(),
@@ -164,17 +164,16 @@ void main() {
       await tester.tap(find.text('Start'));
       await tester.pump();
 
-      expect(find.text('01:00'), findsOneWidget);
+      final timerFinder = find.byKey(const Key('timerText'));
+      expect(timerFinder, findsOneWidget);
 
-      await tester.pump(const Duration(milliseconds: 1100));
+      String read() => (tester.widget<Text>(timerFinder).data)!;
+      final initial = read();
+      expect(initial, anyOf('01:00', '00:59'));
 
-      // Time should have decreased
-      final textFinder = find.byType(Text);
-      final texts = tester.widgetList<Text>(textFinder);
-      final maybeTimerText = texts.firstWhere(
-        (text) => text.data != null && text.data!.contains(':'),
-      );
-      expect(maybeTimerText.data, isNot('01:00'));
+      await tester.pump(const Duration(seconds: 2));
+      final after = read();
+      expect(after, isNot(initial));
     });
   });
 }

--- a/test/screens/timer_screen_test.dart
+++ b/test/screens/timer_screen_test.dart
@@ -151,7 +151,8 @@ void main() {
       expect(find.text('05:00'), findsOneWidget);
     });
 
-    testWidgets('countdown decrements while running (robust to alignment)', (tester) async {
+    testWidgets('countdown decrements while running (robust to alignment)',
+        (tester) async {
       await tester.pumpWidget(
         const ProviderScope(
           child: EleuMindApp(),

--- a/test/services/timer_service_test.dart
+++ b/test/services/timer_service_test.dart
@@ -1,0 +1,149 @@
+/*
+ * EleuMind
+ * A privacy-first, offline meditation timer.
+ * 
+ * Copyright (C) 2025 EleuCode
+ *
+ * This file is part of EleuMind.
+ *
+ * EleuMind is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * EleuMind is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with EleuMind.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:eleumind/services/timer_service.dart';
+
+void main() {
+  group('TimerNotifier', () {
+    late TimerNotifier timerNotifier;
+
+    setUp(() {
+      timerNotifier = TimerNotifier();
+    });
+
+    tearDown(() {
+      timerNotifier.dispose();
+    });
+
+    test('initial state is idle with 5 minutes duration', () {
+      expect(timerNotifier.state.status, TimerStatus.idle);
+      expect(timerNotifier.state.totalDuration, const Duration(minutes: 5));
+      expect(timerNotifier.state.remainingDuration, const Duration(minutes: 5));
+    });
+
+    test('setDuration updates duration when idle', () {
+      timerNotifier.setDuration(const Duration(minutes: 10));
+      
+      expect(timerNotifier.state.totalDuration, const Duration(minutes: 10));
+      expect(timerNotifier.state.remainingDuration, const Duration(minutes: 10));
+    });
+
+    test('setDuration does not update when running', () {
+      timerNotifier.start();
+      timerNotifier.setDuration(const Duration(minutes: 10));
+      
+      expect(timerNotifier.state.totalDuration, const Duration(minutes: 5));
+    });
+
+    test('start changes status to running', () {
+      timerNotifier.start();
+      
+      expect(timerNotifier.state.status, TimerStatus.running);
+      expect(timerNotifier.state.startedAt, isNotNull);
+    });
+
+    test('pause changes status to paused', () {
+      timerNotifier.start();
+      timerNotifier.pause();
+      
+      expect(timerNotifier.state.status, TimerStatus.paused);
+    });
+
+    test('resume from pause changes status back to running', () {
+      timerNotifier.start();
+      timerNotifier.pause();
+      timerNotifier.resume();
+      
+      expect(timerNotifier.state.status, TimerStatus.running);
+    });
+
+    test('stop resets to initial state', () {
+      timerNotifier.setDuration(const Duration(minutes: 10));
+      timerNotifier.start();
+      timerNotifier.stop();
+      
+      expect(timerNotifier.state.status, TimerStatus.idle);
+      expect(timerNotifier.state.totalDuration, const Duration(minutes: 10));
+      expect(timerNotifier.state.remainingDuration, const Duration(minutes: 10));
+    });
+
+    test('multiple pause/resume cycles maintain correct time', () async {
+      timerNotifier.setDuration(const Duration(seconds: 10));
+      
+      // Start timer.
+      timerNotifier.start();
+      await Future.delayed(const Duration(milliseconds: 500));
+      
+      // First pause.
+      timerNotifier.pause();
+      final firstPauseRemaining = timerNotifier.state.remainingDuration;
+      expect(firstPauseRemaining.inMilliseconds, 
+             lessThan(const Duration(seconds: 10).inMilliseconds));
+      
+      // Wait while paused (time should not decrease).
+      await Future.delayed(const Duration(milliseconds: 500));
+      expect(timerNotifier.state.remainingDuration, firstPauseRemaining);
+      
+      // Resume.
+      timerNotifier.resume();
+      await Future.delayed(const Duration(milliseconds: 500));
+      
+      // Second pause.
+      timerNotifier.pause();
+      final secondPauseRemaining = timerNotifier.state.remainingDuration;
+      expect(secondPauseRemaining.inMilliseconds, 
+             lessThan(firstPauseRemaining.inMilliseconds));
+    });
+
+    test('timer updates remaining time while running', () async {
+      timerNotifier.setDuration(const Duration(seconds: 5));
+      timerNotifier.start();
+      
+      final initialRemaining = timerNotifier.state.remainingDuration;
+      await Future.delayed(const Duration(milliseconds: 500));
+      final afterDelay = timerNotifier.state.remainingDuration;
+      
+      expect(afterDelay.inMilliseconds, 
+             lessThan(initialRemaining.inMilliseconds));
+    });
+
+    test('timer completes and returns to idle when time runs out', () async {
+      timerNotifier.setDuration(const Duration(milliseconds: 500));
+      timerNotifier.start();
+      
+      await Future.delayed(const Duration(seconds: 1));
+      
+      expect(timerNotifier.state.status, TimerStatus.idle);
+      expect(timerNotifier.state.remainingDuration, Duration.zero);
+    });
+  });
+
+  group('formatDuration', () {
+    test('formats duration correctly', () {
+      expect(formatDuration(const Duration(minutes: 5, seconds: 30)), '05:30');
+      expect(formatDuration(const Duration(minutes: 0, seconds: 5)), '00:05');
+      expect(formatDuration(const Duration(minutes: 10)), '10:00');
+      expect(formatDuration(const Duration(hours: 1, minutes: 5)), '65:00');
+    });
+  });
+}

--- a/test/services/timer_service_test.dart
+++ b/test/services/timer_service_test.dart
@@ -64,7 +64,8 @@ void main() {
       timerNotifier.setDuration(const Duration(minutes: 10));
 
       expect(timerNotifier.state.totalDuration, const Duration(minutes: 10));
-      expect(timerNotifier.state.remainingDuration, const Duration(minutes: 10));
+      expect(
+          timerNotifier.state.remainingDuration, const Duration(minutes: 10));
     });
 
     test('setDuration does not update when running', () {
@@ -103,10 +104,12 @@ void main() {
 
       expect(timerNotifier.state.status, TimerStatus.idle);
       expect(timerNotifier.state.totalDuration, const Duration(minutes: 10));
-      expect(timerNotifier.state.remainingDuration, const Duration(minutes: 10));
+      expect(
+          timerNotifier.state.remainingDuration, const Duration(minutes: 10));
     });
 
-    test('multiple pause/resume cycles maintain correct time (approx)', () async {
+    test('multiple pause/resume cycles maintain correct time (approx)',
+        () async {
       timerNotifier.setDuration(const Duration(seconds: 4));
       timerNotifier.start();
       await Future.delayed(const Duration(milliseconds: 400));
@@ -133,7 +136,8 @@ void main() {
       await Future.delayed(const Duration(milliseconds: 1200));
       final afterDelay = timerNotifier.state.remainingDuration;
 
-      expect(afterDelay.inMilliseconds, lessThan(initialRemaining.inMilliseconds));
+      expect(
+          afterDelay.inMilliseconds, lessThan(initialRemaining.inMilliseconds));
     });
 
     test('timer completes and returns to idle when time runs out', () async {
@@ -151,7 +155,8 @@ void main() {
   });
 
   group('Lifecycle + recompute', () {
-    test('rehydrates and recomputes after background/foreground with no drift', () async {
+    test('rehydrates and recomputes after background/foreground with no drift',
+        () async {
       DateTime t0 = DateTime(2025, 1, 1, 12, 0, 0);
 
       DateTime now() => t0;
@@ -177,7 +182,8 @@ void main() {
       notifier.dispose();
     });
 
-    test('process kill safety: new instance can resume from persisted snapshot', () async {
+    test('process kill safety: new instance can resume from persisted snapshot',
+        () async {
       DateTime t0 = DateTime(2025, 1, 1, 12, 0, 0);
 
       DateTime now() => t0;

--- a/test/services/timer_service_test.dart
+++ b/test/services/timer_service_test.dart
@@ -100,7 +100,6 @@ void main() {
       final firstPauseRemaining = timerNotifier.state.remainingDuration;
 
       await Future.delayed(const Duration(milliseconds: 400));
-      // still paused
       expect(timerNotifier.state.remainingDuration, firstPauseRemaining);
 
       timerNotifier.resume();
@@ -141,7 +140,7 @@ void main() {
 
       final notifier = TimerNotifier(now: now);
       notifier.setDuration(const Duration(seconds: 10));
-      notifier.start(); // startedAt = t0
+      notifier.start();
 
       // Simulate 3s running, then app pause (persist)
       t0 = t0.add(const Duration(seconds: 3));

--- a/test/services/timer_service_test.dart
+++ b/test/services/timer_service_test.dart
@@ -20,7 +20,6 @@
  * along with EleuMind.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import 'dart:async';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:eleumind/services/timer_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -141,8 +140,6 @@ void main() {
       timerNotifier.setDuration(const Duration(milliseconds: 900));
       timerNotifier.start();
 
-      // The notifier marks completion on the next aligned tick.
-      // Wait until it reports idle (with a safety timeout).
       await _waitForCondition(
         () => timerNotifier.state.status == TimerStatus.idle,
         timeout: const Duration(seconds: 3),
@@ -156,7 +153,8 @@ void main() {
   group('Lifecycle + recompute', () {
     test('rehydrates and recomputes after background/foreground with no drift', () async {
       DateTime t0 = DateTime(2025, 1, 1, 12, 0, 0);
-      DateTime Function() now = () => t0;
+
+      DateTime now() => t0;
 
       final notifier = TimerNotifier(now: now);
       notifier.setDuration(const Duration(seconds: 10));
@@ -181,7 +179,8 @@ void main() {
 
     test('process kill safety: new instance can resume from persisted snapshot', () async {
       DateTime t0 = DateTime(2025, 1, 1, 12, 0, 0);
-      DateTime Function() now = () => t0;
+
+      DateTime now() => t0;
 
       // Instance A
       final a = TimerNotifier(now: now);


### PR DESCRIPTION
### Changes:
- [x] Implemented countdown timer logic with **start, pause, resume, and stop** behavior
- [x] Chose and integrated **Riverpod** for state management
- [x] Implemented **wall-clock–safe math** (derive remaining time from timestamps)
- [x] Exposed states: **Idle, Running, Paused** (Stop resets to Idle)
- [x] Wired **Start / Pause / Resume / Stop** handlers to update state and remaining time
- [x] Added **lifecycle handling** (persist reference timestamps on pause/background, recompute on resume)
- [x] Created provider/service API for UI to access current time and status
- [x] Added **unit tests** for timer math (start, pause, resume, stop, multiple pause cycles)
- [x] Added **widget tests** verifying UI reflects state changes
- [x] Fixed minor analyzer warnings in `timer_screen.dart` and test files
- [x] Added different time options for proper live testing

---

### Notes:
- Timer ticks aligned to wall-clock seconds (no drift across background/foreground)
- Process-kill safety: timer restores correctly from persisted snapshot
- All tests pass locally and in CI
- CI/CD pipeline runs tests + checks before merge (from prior setup)


---

### Feature image:

<img width="1472" height="972" alt="Screenshot 2025-09-08 at 12 40 16 AM" src="https://github.com/user-attachments/assets/a8fbc346-0d96-4453-8299-b84e758abd2e" />

---

Closes #13
